### PR TITLE
Tweak README and harden ci/fuzzit.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ go get github.com/fuzzitdev/example-go
 
 ```bash
 cd /go/src/github.com/fuzzitdev/example-go
-go-fuzz-build -libfuzzer ./...
-clang-9 -fsanitize=fuzzer parser-fuzz.a -o parser-fuzz.libfuzzer
+go-fuzz-build -libfuzzer -o fuzzer.a ./...
+clang-9 -fsanitize=fuzzer fuzzer.a -o fuzzer
 ```
 
 ### Running the fuzzer
 
 ```bash
-./parser-fuzz.libfuzzer
+./fuzzer
 ```
 
 Will print the following output and stacktrace:

--- a/ci/fuzzit.sh
+++ b/ci/fuzzit.sh
@@ -1,5 +1,11 @@
 set -xe
 
+if [ -z ${1+x} ]; then
+    echo "must call with job type as first argument e.g. 'fuzzing' or 'sanity'"
+    echo "see https://github.com/fuzzitdev/example-go/blob/master/.travis.yml"
+    exit 1
+fi
+
 ## Install go-fuzz
 go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
 


### PR DESCRIPTION
Incorrectly calling `ci/fuzzit.sh` was the root cause of https://github.com/fuzzitdev/fuzzit/issues/3 so make it detect such mis-use with clear error message.
